### PR TITLE
fix the link in the readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,5 +13,5 @@ If you are running dory the services will be at `gremlin-ui.docker:8183` and
 
 ## credit
 
-A good chunk of this came from (https://github.com/joov/gremlin-demo)[https://github.com/joov/gremlin-demo]
+A good chunk of this came from [https://github.com/joov/gremlin-demo](https://github.com/joov/gremlin-demo)
 check it out.


### PR DESCRIPTION
The text of the link should be in the square brackets and the link is in parentheses.

BTW thank you for the [article](https://dev.to/designfrontier/neptune-gremlin-local-dev-setup-469l).